### PR TITLE
Fix cleanup of temporary listeners

### DIFF
--- a/Amber Terminal Portfolio/src/main.tsx
+++ b/Amber Terminal Portfolio/src/main.tsx
@@ -1,26 +1,34 @@
-import { StrictMode } from 'react';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
+
 // Force light mode by removing dark class and preventing it from being added
-document.documentElement.classList.remove('dark');
+document.documentElement.classList.remove("dark");
 
 // Override the system preference detection
 const forceLightMode = () => {
   // Always set dark mode to false regardless of localStorage or system preference
-  document.documentElement.classList.toggle('dark', false // Force to false instead of checking localStorage or system preference
-  );
+  document.documentElement.classList.toggle("dark", false);
 };
 
 // Run immediately
 forceLightMode();
 
 // Also run when the DOM is loaded to ensure it applies
-document.addEventListener('DOMContentLoaded', forceLightMode);
+document.addEventListener("DOMContentLoaded", forceLightMode);
 
 // Override system preference changes
-const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-mediaQuery.addEventListener('change', forceLightMode);
-import { createRoot } from 'react-dom/client';
-import './index.css';
-import App from './App.tsx';
-createRoot(document.getElementById('root')!).render(<StrictMode>
+const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+mediaQuery.addEventListener("change", forceLightMode);
+
+const root = createRoot(document.getElementById("root")!);
+root.render(
+  <StrictMode>
     <App />
-  </StrictMode>);
+  </StrictMode>,
+);
+
+// Remove temporary listeners after mounting
+document.removeEventListener("DOMContentLoaded", forceLightMode);
+mediaQuery.removeEventListener("change", forceLightMode);


### PR DESCRIPTION
## Summary
- clean up `forceLightMode` listeners after rendering

## Testing
- `yarn lint`
- `npx prettier src/main.tsx --check`

------
https://chatgpt.com/codex/tasks/task_e_688b11dcc670832699ad57e00910f3e2